### PR TITLE
Fix override logo filter priority

### DIFF
--- a/wp-content/plugins/override-menu-wrapper/override-menu-wrapper.php
+++ b/wp-content/plugins/override-menu-wrapper/override-menu-wrapper.php
@@ -6,8 +6,9 @@
  * Author: ChatGPT
  */
 
+// Use a higher priority than the theme's filter (15) so this override wins.
 add_filter('real_estate_listings_pattern_menu_wrapper', function() {
     return '
     <!-- wp:blockstrap/blockstrap-widget-navbar-brand {"text":"<span class=\"text-primary\"><i class=\"fas fa-home\"></i> Structure</span> ESS","img_max_width":150,"custom_url":"/","brand_font_size":"h4","brand_font_weight":"font-weight-bold"} /-->
     ';
-});
+}, 20);


### PR DESCRIPTION
## Summary
- ensure the logo override filter runs after the theme by increasing its priority

## Testing
- `php -l wp-content/plugins/override-menu-wrapper/override-menu-wrapper.php`


------
https://chatgpt.com/codex/tasks/task_e_688b5b5ea3f48322875b3d7f0203ce8a